### PR TITLE
feat: add cli entry for module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.venv

--- a/src/hugchat/cli.py
+++ b/src/hugchat/cli.py
@@ -1,0 +1,13 @@
+"""Entry for the hugchat command line interface.
+
+simply type 
+```bash
+python -m hugchat.cli
+```
+to start cli.
+"""
+
+from .hugchat import cli
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
## Abstract

After publishing this feature, user can easily enter CLI mode by using the command above:

```bash
python -m hugchat.cli
```

You can add instructions in the README.md after publishing.

## Conflict

This PR has no conflict with #8 . You can merge any one firstly without worrying about the order.