### PR TITLE
Fix bug: Not properly switching to OpenAssistant/oasst-sft-6-llama-30b-xor

### DIFF
--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -244,7 +244,7 @@ class ChatBot:
 
         mdl = ""
         if to == 0:
-            mdl = "OpenAssistant/oasst-sft-6-llama-30b-xor",
+            mdl = "OpenAssistant/oasst-sft-6-llama-30b-xor"
         elif to == 1:
             mdl = "meta-llama/Llama-2-70b-chat-hf"
         elif to == 2:


### PR DESCRIPTION
The misplaced comma caused the error in switching PROPERLY to the model. 

You can check the current version.
```
chatbot.switch_llm(0) # switch to OpenAssistant/oasst-sft-6-llama-30b-xor
print(chatbot.active_model) # returns ["OpenAssistant/oasst-sft-6-llama-30b-xor",] instead of OpenAssistant/oasst-sft-6-llama-30b-xor
id = chatbot.new_conversation() # will return an error
chatbot.change_conversation(id)
print(chatbot.chat("Hi?")) 
```

If new_conversation is opted above and request goes through, check huggingface.co/chat and you'll see that falcon is still the model used
