### PR TITLE
Rewrite streamed json logic to properly break on finalAnswer

### DIFF
--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -395,15 +395,17 @@ class ChatBot:
                         continue
                     res = line.decode("utf-8")
                     obj = json.loads(res)
+                    type = obj['type']
 
-                    if "error" in obj:
-                        raise ChatError(obj["error"])
-
-                    if "finalAnswer" in obj:
+                    if type == "status" or type == "stream":
+                        continue
+                    elif type == "finalAnswer":
+                        res_text = obj["text"]
                         break
-
-                    if "token" in obj:
-                        res_text += obj["token"]
+                    elif "error" in obj:
+                        raise ChatError(obj["error"])
+                    else:
+                        raise ChatError(obj)
             except requests.exceptions.ChunkedEncodingError:
                 pass
             except BaseException as e:


### PR DESCRIPTION
I noticed that the API wasn't cancelling on finalAnswer anymore and was instead waiting for the read timeout.
This fixes this and also uses the type property of the json in order to determine the type of the json we got.
I also improved error handling by throwing on types that aren't known