### PR TITLE
Adds the ability to change the system prompt

### DIFF
--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -218,7 +218,7 @@ class ChatBot:
         '''
 
         if conversation_id is None:
-            raise DeleteConversationError("conversation_id is required.")
+            conversation_id = self.current_conversation
 
         headers = self.get_headers()
 

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -229,8 +229,6 @@ class ChatBot:
         else:
             self.conversation_id_list.pop(self.conversation_id_list.index(conversation_id))
             
-    
-    
     def get_available_llm_models(self) -> list:
         '''
         Get all available models that exists in huggingface.co/chat.
@@ -239,16 +237,19 @@ class ChatBot:
         return self.llms
 
     def set_share_conversations(self, val: bool = True):
-        setting = {
-            "ethicsModalAcceptedAt": "",
-            "searchEnabled": "true",
-            "activeModel": 'tiiuae/falcon-180B-chat',#'meta-llama/Llama-2-70b-chat-hf',
+        settings = {
+            "shareConversationsWithModelAuthors": ("", "on" if val else "")
         }
-        if val:
-            setting['shareConversationsWithModelAuthors'] = 'on'
 
-        self.session.post(self.hf_base_url + "/chat/settings", headers=self.get_headers(ref=True), cookies=self.get_cookies(), allow_redirects=True, data=setting)
+        self.session.post(self.hf_base_url + "/chat/settings", headers={ "Referer": "https://huggingface.co/chat" }, cookies=self.get_cookies(), allow_redirects=True, files=settings)
 
+    def set_system_prompt(self, prompt: str):
+        # We might need to update this setting again if the user changes the model
+        settings = {
+            "customPrompts": ("", json.dumps({self.active_model: prompt})),
+        }
+
+        self.session.post(self.hf_base_url + "/chat/settings", headers={ "Referer": "https://huggingface.co/chat" }, cookies=self.get_cookies(), allow_redirects=True, files=settings)
 
     def switch_llm(self, index: int) -> bool:
         '''


### PR DESCRIPTION
* This commit adds the ability for the user to change the system prompt of the current model with the `set_system_prompt` function
* Fixed the `set_share_conversations` function
* The `delete_conversation` function no longer requires an ID, instead it now defaults back to `self.current_conversation`. This was done because other similar functions, such as `share_conversation`, already do this.