### PR TITLE
Made changes to set_sytem_prompt

### DIFF
--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -280,6 +280,7 @@ class ChatBot:
     def set_system_prompt(self, prompt: str, llmIndex: int = None):
         '''
         Sets a system prompt for the given model index
+        You need to create a new conversation for this to work
         '''
 
         if llmIndex is None:

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -91,11 +91,10 @@ class ChatBot:
         self.__not_summarize_cids = []
         self.accepted_welcome_modal = False # Only when accepted, it can create a new conversation.
         self.llms = [ # The array is up to date as of 16/09/2023.
-                'meta-llama/Llama-2-70b-chat-hf', 
-                'OpenAssistant/oasst-sft-6-llama-30b-xor',
+                'meta-llama/Llama-2-70b-chat-hf'
                 'codellama/CodeLlama-34b-Instruct-hf', 
                 'tiiuae/falcon-180B-chat'
-                ]
+        ]
         self.active_model = self.llms[default_llm]
         self.current_conversation = self.new_conversation()
         self.system_prompts = {}

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -291,7 +291,6 @@ class ChatBot:
         
         self.system_prompts[self.llms[llmIndex]] = prompt
 
-        # We might need to update this setting again if the user changes the model
         settings = {
             "customPrompts": ("", json.dumps(self.system_prompts))
         }

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -63,6 +63,7 @@ class ChatBot:
                 ]
         self.active_model = self.llms[default_llm]
         self.current_conversation = self.new_conversation()
+        self.system_prompts = {}
 
 
     def get_hc_session(self) -> Session:
@@ -243,10 +244,22 @@ class ChatBot:
 
         self.session.post(self.hf_base_url + "/chat/settings", headers={ "Referer": "https://huggingface.co/chat" }, cookies=self.get_cookies(), allow_redirects=True, files=settings)
 
-    def set_system_prompt(self, prompt: str):
+    def set_system_prompt(self, prompt: str, llmIndex: int = None):
+        '''
+        Sets a system prompt for the given model index
+        '''
+
+        if llmIndex is None:
+            llmIndex = self.get_active_llm_index()
+
+        elif llmIndex > len(self.llms)-1 or llmIndex < 0:
+            raise IndexError("Out of range of llm index")
+        
+        self.system_prompts[self.llms[llmIndex]] = prompt
+
         # We might need to update this setting again if the user changes the model
         settings = {
-            "customPrompts": ("", json.dumps({self.active_model: prompt})),
+            "customPrompts": ("", json.dumps(self.system_prompts))
         }
 
         self.session.post(self.hf_base_url + "/chat/settings", headers={ "Referer": "https://huggingface.co/chat" }, cookies=self.get_cookies(), allow_redirects=True, files=settings)


### PR DESCRIPTION
`set_sytem_prompt` will now support multiple LLMs
You can set a system prompt for an individual LLM by calling
```python
set_system_prompt(prompt, llmIndex)
```
system prompts do not reset on program reload