### PR TITLE
Fixed error messages

### DIFF
--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -94,7 +94,7 @@ class ChatBot:
                 'meta-llama/Llama-2-70b-chat-hf'
                 'codellama/CodeLlama-34b-Instruct-hf', 
                 'tiiuae/falcon-180B-chat'
-        ] # The array is up to date as of September 2, 2023
+        ] # The array is up to date as of October 2, 2023
         self.active_model = self.llms[default_llm]
         self.current_conversation = self.new_conversation()
         self.system_prompts = {}

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -205,26 +205,6 @@ class ChatBot:
         self.current_conversation = conversation_id
         return True
     
-        
-    def summarize_conversation(self, conversation_id: str = None) -> str:
-        '''
-        Return a summary of the conversation.
-        '''
-        if conversation_id is None:
-            conversation_id = self.current_conversation
-        
-        headers = self.get_headers(ref = True)
-        r = self.session.post(f"{self.hf_base_url}/chat/conversation/{conversation_id}/summarize", headers=headers, cookies=self.get_cookies())
-        
-        if r.status_code != 200:
-            raise Exception(f"Failed to summarize conversation with status code: {r.status_code}")
-        
-        response = r.json()
-        if 'title' in response:
-            return response['title']
-
-        raise Exception(f"Unknown server response: {response}")
-    
     def share_conversation(self, conversation_id: str = None) -> str:
         '''
         Return a share link of the conversation.

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -91,7 +91,7 @@ class ChatBot:
         self.__not_summarize_cids = []
         self.accepted_welcome_modal = False # It is no longer required to accept the welcome modal
         self.llms = [
-                'meta-llama/Llama-2-70b-chat-hf'
+                'meta-llama/Llama-2-70b-chat-hf',
                 'codellama/CodeLlama-34b-Instruct-hf', 
                 'tiiuae/falcon-180B-chat'
         ] # The array is up to date as of October 2, 2023

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -217,7 +217,7 @@ class ChatBot:
         r = self.session.post(f"{self.hf_base_url}/chat/conversation/{conversation_id}/summarize", headers=headers, cookies=self.get_cookies())
         
         if r.status_code != 200:
-            raise Exception(f"Failed to send chat message with status code: {r.status_code}")
+            raise Exception(f"Failed to summarize conversation with status code: {r.status_code}")
         
         response = r.json()
         if 'title' in response:
@@ -237,7 +237,7 @@ class ChatBot:
         r = self.session.post(f"{self.hf_base_url}/chat/conversation/{conversation_id}/share", headers=headers, cookies=self.get_cookies())
         
         if r.status_code != 200:
-            raise Exception(f"Failed to send chat message with status code: {r.status_code}")
+            raise Exception(f"Failed to share conversation with status code: {r.status_code}")
         
         response = r.json()
         if 'url' in response:

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -89,12 +89,12 @@ class ChatBot:
         self.session = self.get_hc_session()
         self.conversation_id_list = []
         self.__not_summarize_cids = []
-        self.accepted_welcome_modal = False # Only when accepted, it can create a new conversation.
-        self.llms = [ # The array is up to date as of 16/09/2023.
+        self.accepted_welcome_modal = False # It is no longer required to accept the welcome modal
+        self.llms = [
                 'meta-llama/Llama-2-70b-chat-hf'
                 'codellama/CodeLlama-34b-Instruct-hf', 
                 'tiiuae/falcon-180B-chat'
-        ]
+        ] # The array is up to date as of September 2, 2023
         self.active_model = self.llms[default_llm]
         self.current_conversation = self.new_conversation()
         self.system_prompts = {}
@@ -158,7 +158,7 @@ class ChatBot:
         })
 
         if response.status_code != 200:
-            raise Exception(f"Failed to accept ethics modal with status code {response.status_code}. {response.content.decode()}")
+            raise Exception(f"Failed to accept ethics modal with status code: {response.status_code}. {response.content.decode()}")
         
         return True
     
@@ -193,7 +193,7 @@ class ChatBot:
                 err_count += 1
                 logging.debug(f" Failed to create new conversation. Retrying... ({err_count})")
                 if err_count > 5:
-                    raise CreateConversationError(f"Failed to create new conversation. ({err_count})")
+                    raise CreateConversationError(f"Failed to create new conversation with status code: {resp.status_code}. ({err_count})")
                 continue
     
     def change_conversation(self, conversation_id: str) -> bool:
@@ -270,6 +270,9 @@ class ChatBot:
         return self.llms
 
     def set_share_conversations(self, val: bool = True):
+        '''
+        Sets the "Share Conversation with Model Authors setting" to the given val variable
+        '''
         settings = {
             "shareConversationsWithModelAuthors": ("", "on" if val else "")
         }

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -136,7 +136,7 @@ class ChatBot:
     # NOTE: To create a copy when calling this, call it inside of list().
     #       If not, when updating or altering the values in the variable will
     #       also be applied to this class's variable.
-    #       This behaviour is with any function returning self.<var_name>. It
+    #       This behavior is with any function returning self.<var_name>. It
     #       acts as a pointer to the data in the object.
     #
     # Returns a pointer to this objects list that contains id of conversations.
@@ -300,7 +300,7 @@ class ChatBot:
         '''
         Attempts to change current conversation's Large Language Model.
         Requires an index to indicate the model you want to switch.
-        See self.llms for avalible models.
+        See self.llms for available models.
 
         Note: 1. The effect of switch is limited to the current conversation,
         You can manually switch the llm when you start a new conversation.
@@ -308,7 +308,7 @@ class ChatBot:
         2. Only works *after creating a new conversation.*
         :)
         '''
-        # TODO: I will work on making it have a model for each conversation that is changable. - @Zekaroni
+        # TODO: I will work on making it have a model for each conversation that is changeable. - @Zekaroni
         
         if index < len(self.llms) and index >= 0:
             self.active_model = self.llms[index]

--- a/src/hugchat/login.py
+++ b/src/hugchat/login.py
@@ -57,7 +57,7 @@ class Login:
     def SigninWithEmail(self):
         """
         Login through your email and password.
-        PS: I found that it doesn't have any type of encrytion till now,
+        PS: I found that it doesn't have any type of encryption till now,
         which could expose your password to the internet.
         """
         url = "https://huggingface.co/login"


### PR DESCRIPTION
The `summarize_conversation` and `share_conversation` functions were raising inaccurate exception messages, saying `Failed to send chat message with status code: {r.status_code}` when that was not the case.

Also corrected the spelling in some comments of the code