### PR TITLE
Add new HuggingChat model and change System Prompt method

### DIFF
--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -58,6 +58,7 @@ class ChatBot:
         cookies: dict = None,
         cookie_path: str = "",
         default_llm: Union[int, str] = 0,
+        system_prompt: str = ""
     ) -> None:
         """
         default_llm: 
@@ -97,7 +98,7 @@ class ChatBot:
                 'mistralai/Mistral-7B-Instruct-v0.1'
         ] # The array is up to date as of October 2, 2023
         self.active_model = self.llms[default_llm]
-        self.current_conversation = self.new_conversation()
+        self.current_conversation = self.new_conversation(system_prompt=system_prompt)
 
 
     def get_hc_session(self) -> Session:
@@ -162,7 +163,7 @@ class ChatBot:
         
         return True
     
-    def new_conversation(self, system_prompt="", switch_to=False) -> str:
+    def new_conversation(self, system_prompt: str = "", switch_to: bool = False) -> str:
         '''
         Create a new conversation. Return the new conversation id. You should change the conversation by calling change_conversation() after calling this method.
         '''

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -61,10 +61,10 @@ class ChatBot:
     ) -> None:
         """
         default_llm: 
-        0: `meta-llama/Llama-2-70b-chat-hf`
-        1: `OpenAssistant/oasst-sft-6-llama-30b-xor`
-        2: `codellama/CodeLlama-34b-Instruct-hf`
-        3: `tiiuae/falcon-180B-chat`
+        0: 'meta-llama/Llama-2-70b-chat-hf',
+        1: 'codellama/CodeLlama-34b-Instruct-hf', 
+        2: 'tiiuae/falcon-180B-chat',
+        3: 'mistralai/Mistral-7B-Instruct-v0.1'
         """
         if cookies is None and cookie_path == "":
             raise ChatBotInitError("Authentication is required now, but no cookies provided. See tutorial at https://github.com/Soulter/hugging-chat-api")
@@ -93,7 +93,8 @@ class ChatBot:
         self.llms = [
                 'meta-llama/Llama-2-70b-chat-hf',
                 'codellama/CodeLlama-34b-Instruct-hf', 
-                'tiiuae/falcon-180B-chat'
+                'tiiuae/falcon-180B-chat',
+                'mistralai/Mistral-7B-Instruct-v0.1'
         ] # The array is up to date as of October 2, 2023
         self.active_model = self.llms[default_llm]
         self.current_conversation = self.new_conversation()


### PR DESCRIPTION
* ~~Added the new model from the HuggingFace UI, `mistralai/Mistral-7B-Instruct-v0.1`~~
* [Added the ability for the module to automatically fetch the available LLMs from the HuggingChat servers](https://github.com/Soulter/hugging-chat-api/pull/105#issuecomment-1749788145)
* Made changes to the method in which the user is able to change the system prompt. Before, the system prompt was set per model and applied to new conversations. With the recent changes, it now applies per conversation. (This change was made because of changes in the HuggingFace API and how they dealt with system prompts)
* [Conversations are now stored as custom Conversation objects instead of just a string with the conversation ID](https://github.com/Soulter/hugging-chat-api/pull/105#issuecomment-1749824995)

Here is how you would set a system prompt with the new changes:
```python
chatbot.new_conversation(switch_to=True, system_prompt="My name is Jane.")

print(chatbot.query("What is my name?")) # Your name is Jane!
```