### PR TITLE
Various small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ chatbot.change_conversation(id)
 # Get conversation list
 conversation_list = chatbot.get_conversation_list()
 
-# Switch model (default: meta-llama/Llama-2-70b-chat-hf. )
-chatbot.switch_llm(0) # Switch to `OpenAssistant/oasst-sft-6-llama-30b-xor`
-chatbot.switch_llm(1) # Switch to `meta-llama/Llama-2-70b-chat-hf`
+# Get the available models
+models = chatbot.get_available_llm_models()
+
+# Switch model to the given index
+chatbot.switch_llm(0) # Switch to the first model
+chatbot.switch_llm(1) # Switch to the second model
 ```
 
 The `query()` function receives these parameters:

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -37,11 +37,7 @@ class ChatBot:
         system_prompt: str = ""
     ) -> None:
         """
-        default_llm: 
-        0: 'meta-llama/Llama-2-70b-chat-hf',
-        1: 'codellama/CodeLlama-34b-Instruct-hf', 
-        2: 'tiiuae/falcon-180B-chat',
-        3: 'mistralai/Mistral-7B-Instruct-v0.1'
+        Returns a ChatBot object
         """
         if cookies is None and cookie_path == "":
             raise ChatBotInitError(
@@ -73,7 +69,14 @@ class ChatBot:
         self.accepted_welcome_modal = False # It is no longer required to accept the welcome modal
 
         self.llms = self.get_remote_llms()
-        self.active_model = self.llms[default_llm]
+
+        if type(default_llm) == str:
+            if default_llm in self.llms:
+                self.active_model = default_llm
+            else:
+                raise Exception(f"Given model is not in llms list. LLM list: {self.llms}")
+        else:
+            self.active_model = self.llms[default_llm]
 
         self.current_conversation = self.new_conversation(system_prompt=system_prompt)
 
@@ -256,7 +259,6 @@ class ChatBot:
     def get_available_llm_models(self) -> list:
         """
         Get all available models that exists in huggingface.co/chat.
-        Returns a hard-code array.
         """
         return self.llms
 

--- a/src/hugchat/login.py
+++ b/src/hugchat/login.py
@@ -13,8 +13,8 @@ class Login:
         #     logging.debug("Cookie directory not found, creating...")
         #     os.makedirs(self.COOKIE_DIR)
         # logging.debug(f"Cookie store path: {self.COOKIE_DIR}")
-        self.DEFAULT_PATH_DIR = os.path.dirname(os.path.abspath(__file__)) + "/usercookies"
-        self.DEFAULT_COOKIE_PATH = self.DEFAULT_PATH_DIR + f"/{email}.json"
+        self.DEFAULT_PATH_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "usercookies")
+        self.DEFAULT_COOKIE_PATH = self.DEFAULT_PATH_DIR + os.path.join(f"{email}.json")
         
         self.email: str = email
         self.passwd: str = passwd

--- a/src/hugchat/message.py
+++ b/src/hugchat/message.py
@@ -103,7 +103,7 @@ class Message(Generator):
                     self.error = ChatError(a["error"])
                     self.msg_status = MSGSTATUS_REJECTED
                 else:
-                    self.error = ChatError(f"Unknow json response: {a}")
+                    self.error = ChatError(f"Unknown json response: {a}")
 
             # If _stream_yield_all is True, yield all responses from the server.
             if self._stream_yield_all or t == MSGTYPE_STREAM:


### PR DESCRIPTION
* Updated documentation to remove fixed models in the readme as they were outdated -- **Needs to be translated to `README_cn.md`**
* Fixed a typo in an error involving an invalid JSON response
* Program now uses `os.path.join` to join together cookie path in order to be more compatible with compatible OSs
* The `default_llm` parameter now works properly when passed as a string object in the ChatBot init function (before it raised an error when you tried to use a string, even though the parameter said that it was compatible with both `str` and `int` objects)