### PR TITLE
Update docs & allows user to query specific conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,6 @@ chatbot.delete_all_conversations()
 The `query()` function receives these parameters:
 
 - `text`: Required[str].
-- `temperature`: Optional[float]. Default is 0.9
-- `top_p`: Optional[float]. Default is 0.95
-- `repetition_penalty`: Optional[float]. Default is 1.2
-- `top_k`: Optional[int]. Default is 50
-- `truncate`: Optional[int]. Default is 1024
-- `watermark`: Optional[bool]. Default is False
-- `max_new_tokens`: Optional[int]. Default is 1024
-- `stop`: Optional[list]. Default is ["`</s>`"]
-- `return_full_text`: Optional[bool]. Default is False
-- `stream`: Optional[bool]. Default is True
-- `use_cache`: Optional[bool]. Default is False
-- `is_retry`: Optional[bool]. Default is False
 - `retry_count`: Optional[int]. Number of retries for requesting huggingchat. Default is 5
 - `web_search` : Optional[bool]. Whether to use online search.
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -86,18 +86,6 @@ chatbot.switch_llm(1) # 切换到第二个模型
 `query()` 函数接受以下参数:
 
 - `text`: Required[str].
-- `temperature`: Optional[float]. Default is 0.9
-- `top_p`: Optional[float]. Default is 0.95
-- `repetition_penalty`: Optional[float]. Default is 1.2
-- `top_k`: Optional[int]. Default is 50
-- `truncate`: Optional[int]. Default is 1024
-- `watermark`: Optional[bool]. Default is False
-- `max_new_tokens`: Optional[int]. Default is 1024
-- `stop`: Optional[list]. Default is ["`</s>`"]
-- `return_full_text`: Optional[bool]. Default is False
-- `stream`: 是否为流式响应. Optional[bool]. Default is False
-- `use_cache`: Optional[bool]. Default is False
-- `is_retry`: Optional[bool]. Default is False
 - `retry_count`: 重试次数. Optional[int]. Default is 5
 - `web_search` : 是否使用联网搜索. Optional[bool]
 

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -14,11 +14,23 @@ from .message import Message
 from .exceptions import *
 
 class conversation:
-    title: str = None
-    model: str = None
-    id: str = None
-    system_prompt: str = None
-    history: list = []
+    def __init__(
+        self,
+        id: str = None,
+        title: str = None,
+        model: str = None,
+        system_prompt: str = None,
+        history: list = []
+    ):
+        '''
+        Returns a conversation object
+        '''
+
+        self.id = id
+        self.title = title
+        self.model = model
+        self.system_prompt = system_prompt
+        self.history = history
 
     def __str__(self) -> str:
         return self.id
@@ -181,10 +193,7 @@ class ChatBot:
                 logging.debug(resp.text)
                 cid = json.loads(resp.text)['conversationId']
 
-                c = conversation()
-                c.id = cid
-                c.system_prompt = system_prompt
-                c.model = self.active_model
+                c = conversation(id=cid, system_prompt=system_prompt, model=self.active_model)
 
                 self.conversation_list.append(c)
                 self.__not_summarize_cids.append(cid) # For the 1st chat, the conversation needs to be summarized.
@@ -379,10 +388,7 @@ class ChatBot:
 
         for index in conversationIndices:
             conversation_data = data[index]
-            c = conversation()
-            c.id = data[conversation_data["id"]]
-            c.title = data[conversation_data["title"]]
-            c.model = data[conversation_data["model"]]
+            c = conversation(id=data[conversation_data["id"]], title=data[conversation_data["title"]], model=data[conversation_data["model"]])
 
             conversations.append(c)
 
@@ -425,8 +431,7 @@ class ChatBot:
         Returns a conversation object from the given conversation_id.
         '''
 
-        c = conversation()
-        c.id = conversation_id
+        c = conversation(id=conversation_id)
 
         return self.get_conversation_info(c)
 

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -425,24 +425,10 @@ class ChatBot:
         Returns a conversation object from the given conversation_id.
         '''
 
-        r = self.session.post(self.hf_base_url + f"/chat/__data.json", headers=self.get_headers(ref=False), cookies=self.get_cookies())
+        c = conversation()
+        c.id = conversation_id
 
-        if r.status_code != 200:
-            raise Exception(f"Failed to get conversation from id with status code: {r.status_code}")
-
-        data = r.json()["nodes"][0]["data"]
-        conversationIndices = data[data[0]["conversations"]]
-
-        for index in conversationIndices:
-            conversation_data = data[index]
-            if data[conversation_data["id"]] == conversation_id:
-                c = conversation()
-                c.id = conversation_id
-                c.title = data[conversation_data["title"]]
-                c.model = data[conversation_data["model"]]
-                # unable to get system_prompt from returned data after first glance
-
-                return c
+        return self.get_conversation_info(c)
 
     def check_operation(self) -> bool:
         r = self.session.post(

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -35,6 +35,46 @@ class conversation:
     def __str__(self) -> str:
         return self.id
 
+
+# For future use -- is not used currently
+class model:
+    def __init__(
+        self,
+        id: str = None,
+        name: str = None,
+        displayName: str = None,
+
+        preprompt: str = None,
+        promptExamples: list = None,
+        websiteUrl: str = None,
+        description: str = None,
+
+        datasetName: str = None,
+        datasetUrl: str = None,
+        modelUrl: str = None,
+        parameters: dict = None
+    ):
+        '''
+        Returns a model object
+        '''
+
+        self.id: str = id,
+        self.name: str = name,
+        self.displayName: str = displayName,
+
+        self.preprompt: str = preprompt,
+        self.promptExamples: list = promptExamples,
+        self.websiteUrl: str = websiteUrl,
+        self.description: str = description,
+
+        self.datasetName: str = datasetName,
+        self.datasetUrl: str = datasetUrl,
+        self.modelUrl: str = modelUrl,
+        self.parameters: dict = parameters
+
+    def __str__(self) -> str:
+        return self.id
+
 class ChatBot:
     cookies: dict
     """Cookies for authentication"""


### PR DESCRIPTION
* Updated documentation to no longer have unused parameters
* Added the ability to use `chatbot.query` on a specific conversation instead of having to switch to it first. Useful in the scenario of a server generating a response with `hugchat`, for example.
* Now resets the `chatbot.current_conversation` to `None` when it is deleted with the `delete_conversation` method or the `delete_all_conversations` method.
* `get_conversation_from_id` method now requests information from `get_conversation_info` instead of repeating code
* Added `__init__` function to `conversation` class
* Add a class to represent models - **Not currently used** but could be used in the future

Here is some example usage of the changes:
```python
chatbot = hugchat.ChatBot(cookies=cookies.get_dict()), system_prompt="My name is Jane.")
different_conversation = chatbot.new_conversation(system_prompt="My name is Bob", switch_to=False)
print(chatbot.query("What is my name?", conversation=different_conversation)) # Will reply "Your name is Bob", even though it is not `chatbot.current_conversation`

print(chatbot.current_conversation) # Will print a conversation ID
chatbot.delete_conversation() # Deletes the active conversation
print(chatbot.current_conversation) # Returns None
```