### PR TITLE
Add `close-stale-issues` GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '18 0 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue was marked as stale because of inactivity'
+        close-issue-message: 'This issue was closed because of inactivity'
+        stale-pr-message: 'This pull request was marked as stale because of inactivity'
+        close-pr-message: 'This pull request was closed because of inactivity'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
The action automatically marks and then closes issues and pull requests that are inactive
See more about this specific GitHub Action at [the action's marketplace page](https://github.com/marketplace/actions/close-stale-issues)