### PR TITLE
Fix TypeError

### DIFF
--- a/src/hugchat/cli.py
+++ b/src/hugchat/cli.py
@@ -98,7 +98,7 @@ def cli():
 
         if question == "/new":
             cid = chatbot.new_conversation()
-            print("The new conversation ID is: " + cid)
+            print("The new conversation ID is: " + str(cid))
             chatbot.change_conversation(cid)
             print("Conversation changed successfully.")
             continue


### PR DESCRIPTION
Fixes this error which occurs when creating a new conversation with "/new"

TypeError: can only concatenate str (not "conversation") to str