### PR TITLE
Skip unlisted models in get_remote_llms

### DIFF
--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -468,6 +468,10 @@ class ChatBot:
         for modelIndex in modelsIndices:
             model_data = data[modelIndex]
 
+            # Model is unlisted, skip it
+            if data[model_data["unlisted"]]:
+                continue
+
             m = model(
                 id=return_data_from_index(model_data["id"]),
                 name=return_data_from_index(model_data["name"]),

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -11,7 +11,7 @@ from typing import Union
 from requests.sessions import RequestsCookieJar
 
 from .message import Message
-from  . import exceptions
+from . import exceptions
 
 
 class conversation:


### PR DESCRIPTION
* Fixed a small spacing issue
* Now skips models that are classified as "unlisted"