### PR TITLE
adding UTF-8 languages support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ fortest/
 .mypy_cache
 .vscode/
 build/
+venv

--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -679,6 +679,7 @@ class ChatBot:
                 headers=headers,
                 cookies=self.session.cookies.get_dict(),
             )
+            resp.encoding='utf-8'
 
             if resp.status_code != 200:
                 retry_count -= 1


### PR DESCRIPTION
I have added a line that improves the readability of responses. Previously, there was an issue with character encoding on certain languages which caused communication with the chat to stop working. This update should resolve those problems and make interactions smoother in non-Latin based scripts such as Chinese [Simplified and Traditional forms], Japanese, Korean, Russian, and others.