### PR TITLE
fix: Fix check of default_llm for being a string

### DIFF
--- a/src/hugchat/hugchat.py
+++ b/src/hugchat/hugchat.py
@@ -149,7 +149,7 @@ class ChatBot:
 
         self.llms = self.get_remote_llms()
 
-        if isinstance(type(default_llm), str):
+        if isinstance(default_llm, str):
             self.active_model = self.get_llm_from_name(default_llm)
             if self.active_model is None:
                 raise Exception(


### PR DESCRIPTION
Previously the code was calling type within isinstance which caused the check to fail even if `default_llm` is a string.