### PR TITLE
Fix webSearch and refactor testing

### DIFF
--- a/.github/workflows/hugchat_integration_test.yml
+++ b/.github/workflows/hugchat_integration_test.yml
@@ -1,0 +1,42 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: hugchat integration test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+      max-parallel: 1
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest requests pytest-rerunfailures
+        pip uninstall hugchat
+    # - name: Lint with flake8
+    #   run: |
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        cd src
+        pytest integration_test.py -s --reruns 3 --reruns-delay 5

--- a/src/integration_test.py
+++ b/src/integration_test.py
@@ -1,0 +1,123 @@
+"""
+For test hugchat
+"""
+
+# import os
+import logging
+
+import pytest
+
+from .hugchat.message import MSGSTATUS_RESOLVED, Message, MSGTYPE_ERROR, RESPONSE_TYPE_WEB
+from .hugchat import hugchat, cli
+from .hugchat.login import Login
+import sys
+from unittest.mock import patch
+
+logging.basicConfig(level=logging.DEBUG)
+
+EMAIL = "just_a_temp_email@iubridge.com"
+PASSWORD = "FOR_TEST_DO_NOT_LOGIN_a1"
+
+
+@pytest.fixture(scope="session")
+def login_to_chatbot():
+    sign = Login(EMAIL, PASSWORD)
+    cookies = sign.login()
+    sign.saveCookiesToDir("./fortest")
+    assert cookies is not None
+    chatbot = hugchat.ChatBot(cookies=cookies.get_dict(), default_llm=0)
+    yield chatbot
+    chatbot.session.close()
+
+
+class TestAPI:
+    """
+    test hugchat api
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, login_to_chatbot):
+        """
+        setup
+        """
+        self.chatbot = login_to_chatbot
+
+    def test_create_conversation(self):
+        """
+        test create conversation module
+        """
+        global my_conversation
+        res = self.chatbot.new_conversation()
+        assert res is not None
+        self.chatbot.change_conversation(res)
+        my_conversation = res
+        print("Test create conversation:", str(res))
+
+    def test_chat_without_web_search(self):
+        """
+        test chat module without web search
+        """
+        res = str(self.chatbot.chat("Just reply me `test_ok`"))
+        assert res is not None
+
+    def test_chat_web_search(self):
+        """
+        test chat module with web search
+        """
+        res = str(
+            self.chatbot.chat(
+                "What's the weather like in London today? Reply length limited within 20 words.",
+                web_search=True))
+        assert res is not None
+
+    def test_generator(self):
+        """
+        test generator module
+        """
+        res = self.chatbot.chat("Just reply me `test_ok`",
+                                _stream_yield_all=True)
+        for i in res:
+            print(i, flush=True)
+
+        assert res is not None
+
+    # def test_delete_conversation(self):
+    #     """
+    #     test delete conversation module
+    #     """
+    #     chatbot.delete_conversation(my_conversation)
+
+    def test_delete_all_conversations(self):
+        """
+        test delete all conversations module
+        """
+        self.chatbot.delete_all_conversations()
+
+    def test_cli(self):
+        global times_run
+        times_run = -1
+
+        # many not enabled because the CLI is currently very broken
+        return_strings = [
+            "/help",
+            "Hello!",
+            # "/new",
+            # "/ids",
+            # "/sharewithauthor off"
+            "/exit"
+        ]
+
+        def input_callback(_):
+            global times_run
+            times_run += 1
+
+            return return_strings[times_run]
+
+        sys.argv = [sys.argv[0]]
+
+        sys.argv.append("-u")
+        sys.argv.append(EMAIL)
+
+        with patch("getpass.getpass", side_effect=lambda _: PASSWORD):
+            with patch('builtins.input', side_effect=input_callback):
+                cli.cli()

--- a/src/unit_test.py
+++ b/src/unit_test.py
@@ -4,119 +4,85 @@ For test hugchat
 
 # import os
 import logging
-from .hugchat import hugchat, cli
-from .hugchat.login import Login
+
+from .hugchat.message import MSGSTATUS_RESOLVED, RESPONSE_TYPE_FINAL, Message, MSGTYPE_ERROR, RESPONSE_TYPE_WEB
 import sys
-from unittest.mock import patch
 
 logging.basicConfig(level=logging.DEBUG)
 
-EMAIL = "just_a_temp_email@iubridge.com"
-PASSWORD = "FOR_TEST_DO_NOT_LOGIN_a1"
 
-chatbot: hugchat.ChatBot = None
-my_conversation: hugchat.Conversation = None
+class MockResponse():
+    """
+    mock a respone from hugchat api
+    """
+
+    def __init__(self, response_list):
+        self.index = 0
+        self.response_list = response_list
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.response_list):
+            raise StopIteration
+        result = self.response_list[self.index]
+        self.index += 1
+        return result
 
 
-class TestAPI(object):
+class Test(object):
     """
     test hugchat api
     """
-    def test_login(self):
-        """
-        test login module
-        """
-        global chatbot
-        sign = Login(EMAIL, PASSWORD)
-        cookies = sign.login()
-        sign.saveCookiesToDir("./fortest")
-        assert cookies is not None
-        chatbot = hugchat.ChatBot(cookies=cookies.get_dict(), default_llm=0)
 
-    def test_create_conversation(self):
-        """
-        test create conversation module
-        """
-        global my_conversation
-        res = chatbot.new_conversation()
-        assert res is not None
-        chatbot.change_conversation(res)
-        my_conversation = res
-        print("Test create conversation:", str(res))
+    def test_web_search_failed_results(self):
+        response_list = [{
+            "type":
+            RESPONSE_TYPE_WEB,
+            "messageType":
+            MSGTYPE_ERROR,
+            "message":
+            "Failed to parse webpage",
+            "args": [
+                "This operation was aborted",
+                "https://www.accuweather.com/en/gb/london/ec4a-2/weather-forecast/328328"
+            ]
+        }, {
+            "type":
+            RESPONSE_TYPE_WEB,
+            "messageType":
+            RESPONSE_TYPE_WEB,
+            "sources": [{
+                "title": "1",
+                "link": "2",
+                "hostname": "3"
+            }]
+        }, {
+            "type":
+            RESPONSE_TYPE_WEB,
+            "messageType":
+            MSGTYPE_ERROR,
+            "message":
+            "Failed to parse webpage",
+            "args": [
+                "This operation was aborted",
+                "https://www.accuweather.com/en/gb/london/ec4a-2/weather-forecast/328328"
+            ]
+        }, {
+            "type": RESPONSE_TYPE_FINAL,
+            "messageType": "answer",
+            "text": "Funny joke"
+        }]
 
-    def test_chat_without_web_search(self):
-        """
-        test chat module without web search
-        """
-        res = str(chatbot.chat("Just reply me `test_ok`"))
-        assert res is not None
-
-    def test_chat_web_search(self):
-        """
-        test chat module with web search
-        """
-        res = str(chatbot.chat("What's the weather like in London today? Reply length limited within 20 words.", web_search=True))
-        assert res is not None
-
-    def test_generator(self):
-        """
-        test generator module
-        """
-        res = chatbot.chat("Just reply me `test_ok`", _stream_yield_all=True)
-        for i in res:
-            print(i, flush=True)
-
-        assert res is not None
-
-    # def test_delete_conversation(self):
-    #     """
-    #     test delete conversation module
-    #     """
-    #     chatbot.delete_conversation(my_conversation)
-
-    def test_delete_all_conversations(self):
-        """
-        test delete all conversations module
-        """
-        chatbot.delete_all_conversations()
-
-    def test_cli(self):
-        global times_run
-        times_run = -1
-
-        # many not enabled because the CLI is currently very broken
-        return_strings = [
-            "/help",
-            "Hello!",
-            # "/new",
-            # "/ids",
-            # "/sharewithauthor off"
-            "/exit"
-        ]
-
-        def input_callback(_):
-            global times_run
-            times_run += 1
-
-            return return_strings[times_run]
-
-        sys.argv = [sys.argv[0]]
-
-        sys.argv.append("-u")
-        sys.argv.append(EMAIL)
-
-        with patch("getpass.getpass", side_effect=lambda _: PASSWORD):
-            with patch('builtins.input', side_effect=input_callback):
-                cli.cli()
-
-
-if __name__ == "__main__":
-    test = TestAPI()
-    test.test_login()
-    test.test_create_conversation()
-    # test.test_delete_conversation()
-    test.test_chat_without_web_search()
-    test.test_chat_web_search()
-    test.test_delete_all_conversations()
-    test.test_cli()
-    test.test_generator()
+        mock = MockResponse(response_list)
+        response = Message(mock, web_search=True)
+        while True:
+            try:
+                print(response)
+                response = next(response)
+            except StopIteration:
+                break
+        assert len(response.web_search_sources
+                   ) == 1  # only the second web search response is valid.
+        assert response.text == "Funny joke"


### PR DESCRIPTION
Issue #187
  - Skip web search results for websites that failed to parse.
  - Handle the case when response has not finished with `RESPONSE_TYPE_FINAL`.
  - Rename response and message type appropriately.
  - Rename `unit_test.py` to `integration_test.py`, it calls the API.
  - Create `unit_test.py` and implement the test for the response.
  - Rename the workflow for integration tests, and add a new one for unit tests.
  - Use proper pytest fixture for creating a chatbot session.