### PR TITLE
fix: remove 'hostname' property from WebSearchSource

### DIFF
--- a/src/hugchat/message.py
+++ b/src/hugchat/message.py
@@ -17,13 +17,11 @@ MSGSTATUS_REJECTED = 2
 class WebSearchSource:
     title: str
     link: str
-    hostname: str
 
     def __str__(self):
         return json.dumps({
             "title": self.title,
             "link": self.link,
-            "hostname": self.hostname,
         })
 
 
@@ -112,7 +110,6 @@ class Message(Generator):
                         wss = WebSearchSource()
                         wss.title = source["title"]
                         wss.link = source["link"]
-                        wss.hostname = source["hostname"]
                         self.web_search_sources.append(wss)
             elif "messageType" in a:
                 message_type: str = a["messageType"]


### PR DESCRIPTION
The 'hostname' property is no longer present in the JSON response, causing errors in the web search functionality. This commit removes the 'hostname' attribute from the WebSearchSource class and updates the Message class to handle the updated JSON structure correctly.

- Removed 'hostname' attribute from WebSearchSource.
- Updated Message class to process web search sources without 'hostname'.

This fix resolves the issue where the web search results were causing errors due to the missing 'hostname' property.