### PR TITLE
Update README.md - fix broken code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,18 @@ file_list = message_result.get_files_created() # must call wait_until_done() fir
 # tips: model "CohereForAI/c4ai-command-r-plus" can generate images :)
 
 # Stream response
-for resp in chatbot.query(
+for resp in chatbot.chat(
     "Hello",
     stream=True
 ):
     print(resp)
 
 # Web search
-query_result = chatbot.query("Hi!", web_search=True)
+query_result = chatbot.chat("Hi!", web_search=True)
 print(query_result)
 for source in query_result.web_search_sources:
     print(source.link)
     print(source.title)
-    print(source.hostname)
 
 # Create a new conversation
 chatbot.new_conversation(switch_to = True) # switch to the new conversation


### PR DESCRIPTION
It seems `chatbot.query` was replaced with `chatbot.chat`, but the change wasn't reflected in the readme. see https://github.com/Soulter/hugging-chat-api/issues/255 In addition, a broken reference to `source.hostname` was removed.